### PR TITLE
Add support for all currencies

### DIFF
--- a/custom_components/nicehash/account_sensors.py
+++ b/custom_components/nicehash/account_sensors.py
@@ -102,7 +102,10 @@ class BalanceSensor(Entity):
             return ICON_CURRENCY_EUR
         elif self.currency == CURRENCY_USD:
             return ICON_CURRENCY_USD
-        return ICON_CURRENCY_BTC
+        elif self.currency == CURRENCY_BTC:
+            return ICON_CURRENCY_BTC
+
+        return ICON_CURRENCY_USD
 
     @property
     def unit_of_measurement(self):

--- a/custom_components/nicehash/const.py
+++ b/custom_components/nicehash/const.py
@@ -57,6 +57,23 @@ NICEHASH_ATTRIBUTION = "Data provided by NiceHash"
 CURRENCY_BTC = "BTC"
 CURRENCY_USD = "USD"
 CURRENCY_EUR = "EUR"
+SUPPORTED_CURRENCIES = [
+    "ERN","HKD","GGP","RSD","SHP","USD","MYR","PYG","RON","DOP","TWD","AWG",
+    "CVE","BND","RUB","NGN","XCD","JEP","ZWL","HNL","NZD","AFN","MUR","DKK",
+    "CNY","JOD","CHF","COP","XAF","XAG","ZMK","GNF","ZMW","GIP","BTC","MKD",
+    "WST","IDR","IQD","BHD","YER","MAD","KGS","PHP","PEN","BMD","DJF","MVR",
+    "QAR","JPY","SCR","IMP","KRW","HRK","SOS","VUV","NIO","KYD","LAK","ISK",
+    "BOB","IRR","NPR","EGP","BBD","CAD","XAU","CUP","SDG","PKR","UZS","CLF",
+    "CUC","STD","MGA","FJD","DZD","TJS","EURKM","SZL","THB","SRD","BDT",
+    "BTN","CZK","AMD","UGX","TRY","AUD","UAH","HUF","SLL","VND","RWF","LBP",
+    "ANG","SAR","LVL","KHR","BYR","TTD","OMR","LTL","GTQ","ALL","MRO","MWK",
+    "LSL","SBD","BGN","LRD","JMD","CRC","ETB","NAD","GYD","LKR","INR","SEK",
+    "KES","KMF","VEF","ARS","HTG","BAM","BWP","GEL","KZT","AED","KWD","XDR",
+    "EUR","TND","MDL","LYD","BSD","GHS","MOP","PAB","ZAR","AZN","TOP","SVC",
+    "KPW","TMT","BZD","GMD","XOF","UYU","MNT","NOK","XPF","BIF","BYN","FKP",
+    "GBP","MXN","SYP","PGK","MZN","PLN","MMK","SGD","AOA","ILS","CLP","TZS",
+    "CDF","BRL"
+]
 # Balance type
 BALANCE_TYPE_AVAILABLE = "available"
 BALANCE_TYPE_PENDING = "pending"

--- a/custom_components/nicehash/rig_sensors.py
+++ b/custom_components/nicehash/rig_sensors.py
@@ -378,7 +378,7 @@ class RigSpeedSensor(RigSensor):
     @property
     def unit_of_measurement(self):
         """Sensor unit of measurement"""
-        return None
+        return f"{self._unit}"
 
     @property
     def device_state_attributes(self):

--- a/custom_components/nicehash/sensor.py
+++ b/custom_components/nicehash/sensor.py
@@ -20,6 +20,7 @@ from .const import (
     DEVICE_RPM,
     DEVICE_SPEED_RATE,
     DEVICE_SPEED_ALGORITHM,
+    SUPPORTED_CURRENCIES,
 )
 from .nicehash import (
     MiningRig,
@@ -121,7 +122,7 @@ def create_balance_sensors(organization_id, currency, coordinator):
             balance_type=BALANCE_TYPE_TOTAL,
         ),
     ]
-    if currency == CURRENCY_USD or currency == CURRENCY_EUR:
+    if currency in SUPPORTED_CURRENCIES:
         _LOGGER.debug(f"Creating {currency} account balance sensors")
         balance_sensors.append(
             BalanceSensor(
@@ -148,8 +149,7 @@ def create_balance_sensors(organization_id, currency, coordinator):
             )
         )
     else:
-        _LOGGER.warn("Invalid currency: must be EUR or USD")
-
+        _LOGGER.warn("Currency is invalid.")
     return balance_sensors
 
 


### PR DESCRIPTION
Closes #3 

Adds support for currencies other than USD and EUR by using USD as an intermediary currency.

For example, if CAD is selected, the exchange rate will be calculated by multiplying the BTC->USD rate by the USD->CAD rate.

I've tested the result against my own account (currently have a balance of ~ CAD$70, and I can confirm that the amount reported in Home Assistant matches what's reported in the NiceHash UI, to the cent. So it's likely that NiceHash is using the exact same formula.

One downside of my implementation is that the USD currency icon will be used for all non-EUR currencies.